### PR TITLE
fix: set javaFieldType for domain entities when no database is selected

### DIFF
--- a/generators/server/generators/bootstrap/generator.ts
+++ b/generators/server/generators/bootstrap/generator.ts
@@ -179,6 +179,8 @@ export default class ServerBootstrapGenerator extends BaseApplicationGenerator<S
       prepareFieldsForTemplates({ application, entity, field }) {
         if (application.databaseTypeAny) {
           prepareServerFieldForTemplates(application, entity, field, this);
+        } else if (entity.entityDomainLayer) {
+          field.javaFieldType = field.blobContentTypeText ? 'String' : field.fieldType;
         }
       },
     });


### PR DESCRIPTION
## Summary

- Fixes jhipster/generator-jhipster#32906
- When `databaseType` is `"no"`, `prepareServerFieldForTemplates` was skipped entirely (gated behind `application.databaseTypeAny`), leaving `javaFieldType` undefined on entity fields
- This caused the Authority entity template to render missing type names (e.g., `private  name;` instead of `private String name;`), resulting in a Java parsing error in the unused-imports transform
- Added a fallback that sets `javaFieldType` for entities with `entityDomainLayer` even without a database

## Test plan

- [x] Existing server bootstrap tests pass
- [x] Existing java domain tests pass
- [ ] Generate a monolithic app with "No database" selected and verify Authority.java renders correctly with `private String name;`

https://claude.ai/code/session_01S55EL7JZgcQxtXZeHShmdz